### PR TITLE
Ensure that CredentialsOverwrite occurs before_configuration

### DIFF
--- a/lib/rails_env_credentials/railtie.rb
+++ b/lib/rails_env_credentials/railtie.rb
@@ -2,10 +2,11 @@
 
 module RailsEnvCredentials
   class Railtie < ::Rails::Railtie
-    initializer 'rails-env-credentials' do
+    config.before_configuration do
       is_credentials_command = Rails.const_defined?(:Command) &&
         Rails::Command.const_defined?(:CredentialsCommand) &&
         !Rails::Command.const_defined?(:EnvCredentialsCommand)
+
       Rails::Application.prepend(CredentialsOverwrite) unless is_credentials_command
     end
   end


### PR DESCRIPTION
This is critical because otherwise, credentials accessed in
initializers/application.rb will default to the production
credentials.

By running this in before_configuration, we ensure RailsEnvCredentials
is properly prepended before anything in application.rb
occurs or any initializers.