### PR TITLE
Fix keyword arguments for Ruby 3.0

### DIFF
--- a/lib/rails_env_credentials.rb
+++ b/lib/rails_env_credentials.rb
@@ -25,7 +25,7 @@ module RailsEnvCredentials
     end
 
     def credentials
-      ActiveSupport::EncryptedConfiguration.new(options)
+      ActiveSupport::EncryptedConfiguration.new(**options)
     end
   end
 end


### PR DESCRIPTION
When using this gem with Ruby 3.0, an error occurred due to a change in the specification of keyword arguments.

This behavior has been deprecated since Ruby 2.7.

Error sample:
```
/usr/local/bundle/gems/activesupport-5.2.6/lib/active_support/encrypted_configuration.rb:14:in `initialize': wrong number of arguments (given 1, expected 0; required keywords: config_path, key_path, env_key, raise_if_missing_key) (ArgumentError)
	from /usr/local/bundle/gems/rails-env-credentials-0.1.4/lib/rails_env_credentials.rb:28:in `new'
	from /usr/local/bundle/gems/rails-env-credentials-0.1.4/lib/rails_env_credentials.rb:28:in `credentials'
	from /usr/local/bundle/gems/rails-env-credentials-0.1.4/lib/rails_env_credentials/railtie.rb:6:in `credentials'
	...
```